### PR TITLE
Adds command processing and send player list to the game host

### DIFF
--- a/src/main/kotlin/com/artifactgames/copyplash/controller/ChannelController.kt
+++ b/src/main/kotlin/com/artifactgames/copyplash/controller/ChannelController.kt
@@ -84,9 +84,16 @@ class ChannelController: TextWebSocketHandler() {
         }
 
     private fun sendPlayerListToHost() {
-        val playerListTextMessage = TextMessage(gson.toJson(playerList.keys.toList()))
+        val playerListTextMessage = TextMessage(playerList.getValidPlayers().toJson())
         host!!.sendMessage(playerListTextMessage)
     }
+
+    private fun HashMap<Player, WebSocketSession>.getValidPlayers(): List<Player> = this
+        .filterKeys { key -> key.nick.isNotEmpty() }
+        .keys
+        .toList()
+
+    private fun List<Player>.toJson(): String = gson.toJson(this)
 
     val processSetNick = {command: CommandRequest, session: WebSocketSession? ->
         session?.run {

--- a/src/main/kotlin/com/artifactgames/copyplash/controller/ChannelController.kt
+++ b/src/main/kotlin/com/artifactgames/copyplash/controller/ChannelController.kt
@@ -29,6 +29,7 @@ class ChannelController: TextWebSocketHandler() {
         println("ConnectionClosed: ${session.toString()}")
         session?.apply {
             playerList.remove(Player(id))
+            sendPlayerListToHost()
         }
     }
 

--- a/src/main/kotlin/com/artifactgames/copyplash/controller/ChannelController.kt
+++ b/src/main/kotlin/com/artifactgames/copyplash/controller/ChannelController.kt
@@ -2,6 +2,7 @@ package com.artifactgames.copyplash.controller
 
 import com.artifactgames.copyplash.model.CommandRequest
 import com.artifactgames.copyplash.model.CommandResponse
+import com.artifactgames.copyplash.model.Player
 import com.artifactgames.copyplash.type.CommandAction
 import com.google.gson.Gson
 import org.springframework.stereotype.Component
@@ -10,7 +11,7 @@ import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
-import java.util.*
+import kotlin.collections.HashMap
 
 @Component
 class ChannelController: TextWebSocketHandler() {
@@ -18,7 +19,7 @@ class ChannelController: TextWebSocketHandler() {
 
     val gson = Gson()
     var host: WebSocketSession? = null
-    val playerList: LinkedList<WebSocketSession?> = LinkedList()
+    val playerList: HashMap<Player, WebSocketSession> = HashMap()
 
     override fun handleTransportError(session: WebSocketSession?, exception: Throwable?) {
         println("Error: ${exception.toString()}")
@@ -26,7 +27,9 @@ class ChannelController: TextWebSocketHandler() {
 
     override fun afterConnectionClosed(session: WebSocketSession?, status: CloseStatus?) {
         println("ConnectionClosed: ${session.toString()}")
-        playerList.remove(session)
+        session?.apply {
+            playerList.remove(Player(id))
+        }
     }
 
     override fun afterConnectionEstablished(session: WebSocketSession?) {
@@ -34,13 +37,18 @@ class ChannelController: TextWebSocketHandler() {
         if (host == null) {
             host = session
         } else {
-            playerList.add(session)
+            session?.apply {
+                playerList[Player(id)] = this
+            }
         }
     }
 
     override fun handleMessage(session: WebSocketSession?, message: WebSocketMessage<*>?) {
         message
                 ?.mapMessageToCommandResponse()
+                ?.also {
+                    process(it, session)
+                }
                 ?.mapToCommandResponse()
                 ?.serialize()
                 ?.let {
@@ -48,12 +56,13 @@ class ChannelController: TextWebSocketHandler() {
                 }
     }
 
-    private fun CommandResponse.serialize(): TextMessage? =
+    private fun process(commandRequest: CommandRequest, session: WebSocketSession?) {
         try {
-            TextMessage(gson.toJson(this))
-        } catch(e: Exception) {
-            null
+            commandRequest.getProcessor()(session)
+        } catch (e:Exception) {
+            e.printStackTrace();
         }
+    }
 
 
     private fun WebSocketMessage<*>.mapMessageToCommandResponse(): CommandRequest? =
@@ -64,12 +73,41 @@ class ChannelController: TextWebSocketHandler() {
             null
         }
 
+    private fun CommandRequest.getProcessor(): (session: WebSocketSession?) -> Any? =
+        when(action) {
+            CommandAction.SET_NICK -> {session: WebSocketSession? ->
+                processSetNick(this, session)
+                sendPlayerListToHost()
+            }
+            else -> { _ -> }
+        }
+
+    private fun sendPlayerListToHost() {
+        val playerListTextMessage = TextMessage(gson.toJson(playerList.keys.toList()))
+        host!!.sendMessage(playerListTextMessage)
+    }
+
+    val processSetNick = {command: CommandRequest, session: WebSocketSession? ->
+        session?.run {
+            val player = Player(id, command.payload ?: throw Exception())
+            playerList.remove(player)
+            playerList[player] = session
+        }
+    }
+
     private fun CommandRequest.mapToCommandResponse(): CommandResponse? =
         when(action) {
             CommandAction.SET_NICK -> CommandResponse(CommandAction.SET_NICK_SUCCESS)
             else -> {
                 null
             }
+        }
+
+    private fun CommandResponse.serialize(): TextMessage? =
+        try {
+            TextMessage(gson.toJson(this))
+        } catch(e: Exception) {
+            null
         }
 
 }

--- a/src/main/kotlin/com/artifactgames/copyplash/model/Player.kt
+++ b/src/main/kotlin/com/artifactgames/copyplash/model/Player.kt
@@ -1,0 +1,11 @@
+package com.artifactgames.copyplash.model
+
+data class Player(val id: String, val nick: String = "") {
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return (other is Player) && other.id == id
+    }
+}


### PR DESCRIPTION
This pull request resolve #5, where the host required to know the players that joined to the lobby.

An event is sent to the host, with the lobby's user list, each time that:
 - A user set his nick
 - A user leaves the lobby