### PR TITLE
Encapsulate player list in a wrapper class to send objects to the client

### DIFF
--- a/src/main/kotlin/com/artifactgames/copyplash/controller/ChannelController.kt
+++ b/src/main/kotlin/com/artifactgames/copyplash/controller/ChannelController.kt
@@ -3,6 +3,7 @@ package com.artifactgames.copyplash.controller
 import com.artifactgames.copyplash.model.CommandRequest
 import com.artifactgames.copyplash.model.CommandResponse
 import com.artifactgames.copyplash.model.Player
+import com.artifactgames.copyplash.model.PlayerList
 import com.artifactgames.copyplash.type.CommandAction
 import com.google.gson.Gson
 import org.springframework.stereotype.Component
@@ -84,7 +85,7 @@ class ChannelController: TextWebSocketHandler() {
         }
 
     private fun sendPlayerListToHost() {
-        val updatePlayersResponse = CommandResponse(CommandAction.UPDATE_PLAYERS, playerList.getValidPlayers().toJson())
+        val updatePlayersResponse = CommandResponse(CommandAction.UPDATE_PLAYERS, PlayerList(playerList.getValidPlayers()).toJson())
         val playerListTextMessage = TextMessage(updatePlayersResponse.toJson())
         host!!.sendMessage(playerListTextMessage)
     }

--- a/src/main/kotlin/com/artifactgames/copyplash/model/Player.kt
+++ b/src/main/kotlin/com/artifactgames/copyplash/model/Player.kt
@@ -9,3 +9,6 @@ data class Player(val id: String, val nick: String = "") {
         return (other is Player) && other.id == id
     }
 }
+
+
+data class PlayerList(val players: List<Player>)


### PR DESCRIPTION
This pull request fixes #10, by adding a list wrapper class inside the `Player` model and use it on the `ChannelController`