### PR TITLE
Enable CORS config through properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ A web service developed in Kotlin, with the Spring Boot Framework.
    # Use a different port
     SERVER_PORT=8081 gradle bootRun
    ```
+
+### Running with configuration profile
+```bash
+SPRING_PROFILES_ACTIVE=[prod|dev] gradle bootRun
+```
+
+The default profile is `dev`, you can check the profile configuration inside the `src/main/resources/application-*.yaml` files

--- a/src/main/kotlin/com/artifactgames/copyplash/ApiConfig.kt
+++ b/src/main/kotlin/com/artifactgames/copyplash/ApiConfig.kt
@@ -1,0 +1,28 @@
+package com.artifactgames.copyplash
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+
+
+@Component
+@Configuration
+class ApiConfig {
+
+    @Value("#{'\${allowedOrigins}'.split(',')}")
+    private val allowedOrigins: List<String> = listOf()
+
+    @Bean
+    fun corsConfigurer() = object : WebMvcConfigurer {
+        override fun addCorsMappings(registry: CorsRegistry?) {
+            registry!!
+                    .addMapping("/**")
+                    .allowedOrigins(*allowedOrigins.toTypedArray())
+        }
+    }
+
+}

--- a/src/main/kotlin/com/artifactgames/copyplash/WebsocketConfig.kt
+++ b/src/main/kotlin/com/artifactgames/copyplash/WebsocketConfig.kt
@@ -5,6 +5,7 @@ import com.artifactgames.copyplash.model.GameMode
 import com.artifactgames.copyplash.model.Lobby
 import com.artifactgames.copyplash.type.GameModes
 import com.artifactgames.copyplash.type.States
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.config.annotation.EnableWebSocket
@@ -23,6 +24,9 @@ class WebSocketConfig : WebSocketConfigurer {
 
     val lobbies : HashMap<Lobby, Boolean> = HashMap()
 
+    @Value("#{'\${allowedOrigins}'.split(',')}")
+    private val allowedOrigins: List<String> = listOf()
+
     fun getInitialGameMode() = GameMode(GameModes.INSPIRATION, States.START)
 
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
@@ -30,7 +34,7 @@ class WebSocketConfig : WebSocketConfigurer {
 
             val id = UUID.randomUUID()
             // TODO add handshake interceptor to avoid unexpected connections or visitors to the websockets
-            registry.addHandler(ChannelController(), id.toString()).setAllowedOrigins("*")
+            registry.addHandler(ChannelController(), id.toString()).setAllowedOrigins(*allowedOrigins.toTypedArray())
             lobbies[Lobby(id, 0, getInitialGameMode())] = true
         }
     }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,5 @@
+debug: false
+trace: false
+server:
+  port: 8080
+allowedOrigins: '*' # to set multiple origins: 'http://cpp.artifact.games/,http://plash.artifact.games/'

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,1 @@
+# this should be replaced with prod settings

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: dev


### PR DESCRIPTION
This pull request solves #1 issue where CORS allowed origins were not handled.

In here a set of `application-*.yaml` files were added to the project, so that we can configure Spring Boot for different profiles (`dev` and `prod`).     