### PR TITLE
Adds start game event sending to the host when the game master launch the game

### DIFF
--- a/src/main/kotlin/com/artifactgames/copyplash/type/CommandAction.kt
+++ b/src/main/kotlin/com/artifactgames/copyplash/type/CommandAction.kt
@@ -10,9 +10,13 @@ enum class CommandAction {
     RETRIEVE,
     @SerializedName("2")
     UPDATE_PLAYERS,
+    @SerializedName("3")
+    START_GAME,
     @SerializedName("10000")
     SET_NICK,
     @SerializedName("10001")
     SET_NICK_SUCCESS,
+    @SerializedName("10002")
+    LAUNCH_GAME,
 
 }


### PR DESCRIPTION
This pull request:
 - Add new command event types: `START_GAME` for the **host** and `LAUNCH_GAME` for the **client** game master
 - Register the first connected client as game master
 - Send `START_GAME` command to the host when the game master triggers a `LAUNCH_GAME`